### PR TITLE
feat(api,launcher): enforce per-user auth, rate limits, production CO…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ flowchart TD
 curl -X GET https://api.luminakraft.com/v1/launcher_data.json
 ```
 
+#### Headers requeridos por el launcher
+
+- Autenticación (uno de):
+  - `Authorization: Bearer <msToken>` (usuarios Microsoft)
+  - `x-lk-token: <clientToken>` (usuarios offline, token generado por el launcher)
+- Identificador opcional del cliente: `x-luminakraft-client: luminakraft-launcher`
+
+Los límites de tasa se aplican por usuario (UUID de Microsoft o `clientToken`).
+
 ### Ejemplo de Response:
 ```json
 {


### PR DESCRIPTION
…RS, and caching

API
add dual auth: Microsoft Bearer tokens and offline x-lk-token apply per-user rate limiting across /v1 (configurable via env) enable trust proxy and robust CORS incl. preflight handling add ETag/Last-Modified conditional GETs for file-backed endpoints document required headers and flow with a fixed Mermaid diagram

Launcher
attach Authorization or x-lk-token automatically to API requests persistent client-side cache for data/translations/features (localStorage) keep Tauri disk cache for icons/screenshots

docs: update READMEs with auth headers, rate limiting, and caching details